### PR TITLE
Prevent fatal error when expecting JSON, but got HTML

### DIFF
--- a/wwdc11downloader.rb
+++ b/wwdc11downloader.rb
@@ -67,19 +67,23 @@ a.get(base_uri) do |page|
             code_base_url = File.dirname(link.href)
             
             a.get("#{code_base_url}/book.json") do |book_json|
-              book_res = JSON.parse(book_json.body)
-              filename = book_res["sampleCode"]
-              url = "#{code_base_url}/#{filename}"
+              if book_json.body[0,1] == '<'
+                puts " Sorry, this samplecode apparently isn't available yet: #{code_base_url}/book.json"
+              else
+                book_res = JSON.parse(book_json.body)
+                filename = book_res["sampleCode"]
+                url = "#{code_base_url}/#{filename}"
               
-              puts "  Downloading #{url}"
-              begin
-                a.get(url) do |downloaded_file|
-                  open(dirname + "/" + filename, 'wb') do |file|
-                    file.write(downloaded_file.body)
+                puts "  Downloading #{url}"
+                begin
+                  a.get(url) do |downloaded_file|
+                    open(dirname + "/" + filename, 'wb') do |file|
+                      file.write(downloaded_file.body)
+                    end
                   end
+                rescue Exception => e
+                  puts "  Download failed #{e}"
                 end
-              rescue Exception => e
-                puts "  Download failed #{e}"
               end
             end
           end


### PR DESCRIPTION
Hey,

Thanks for the script!  I was getting an error that was crashing the script because apparently some of the samplecode isn't available yet.  I get the same /denied HTML page in the browser.  Some other people are complaining about the same thing in the dev forums.

Commit note:
Added check for HTML page to prevent fatal error on sample code that apparently isn't available yet.

-David
